### PR TITLE
Pass env to subprocesses and fallback to `python`

### DIFF
--- a/build.py
+++ b/build.py
@@ -16,6 +16,10 @@ ASSEMBLER = 'ca65.exe'
 LINKER = 'ld65.exe'
 
 
+def run(args):
+    return sp.run(args, capture_output=True, env=os.environ)
+
+
 def executable_path(path):
     p = pathlib.Path(path)
     if not p.exists():
@@ -33,7 +37,7 @@ def run_assembler(assembler, src, dst):
         str(src),
     ]
     print(' '.join(args))
-    return sp.run(args, capture_output=True)
+    return run(args)
 
 
 def run_linker(linker, cfg_file, input_files, out_file):
@@ -44,27 +48,27 @@ def run_linker(linker, cfg_file, input_files, out_file):
     ]
     args.extend([str(i) for i in input_files])
     print(' '.join(args))
-    return sp.run(args, capture_output=True)
+    return run(args)
 
 
 def run_bmp2chr(tool, src, dst):
     args = [
-        'py', '-3', str(tool),
+        'python', str(tool),
         str(src),
         str(dst),
     ]
     print(' '.join(args))
-    return sp.run(args, capture_output=True)
+    return run(args)
 
 
 def run_bmp2lvl(tool, src, dst):
     args = [
-        'py', '-3', str(tool),
+        'python', str(tool),
         str(src),
         str(dst),
     ]
     print(' '.join(args))
-    return sp.run(args, capture_output=True)
+    return run(args)
 
 
 


### PR DESCRIPTION
When there are multiple installations of Python 3 interpreter, the `py -3` command defaults to the newest version, for example:
```
Installed Pythons found by c:\windows\py.exe Launcher for Windows
 (venv) *
 -3.10-64
 -3.7-64
 ```

and `py -3` runs the 3.10:
```
py -3
Python 3.10.0a5 (tags/v3.10.0a5:b0478d7, Feb  3 2021, 01:44:54) [MSC v.1928 64 bit (AMD64)] on win32
```

This PR addresses the issue by defaulting to `python` and let the caller setup ENV properly so the right is chosen. This works just as expected if virtualenv is used.